### PR TITLE
SONAR-6 (bug) [SonarQube] Remove the declaration of the unused 'url2' variable.

### DIFF
--- a/node.js
+++ b/node.js
@@ -30,7 +30,7 @@ app.get('/greet', (req, res) => {
 });
 
 app.get('/redirect', (req, res) => {
-    const { url ,url2 } = req.query;
+    const { url } = req.query; // Removed unused variable 'url2'
     res.redirect(url);
 });
 


### PR DESCRIPTION
SONAR-6 (bug) [SonarQube] Remove the declaration of the unused 'url2' variable.